### PR TITLE
Sharpen positioning copy across hero, about, and contact

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -5,7 +5,6 @@ import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
 import { Container } from '@/components/ui/Container'
 import { Button } from '@/components/ui/Button'
-import { Card } from '@/components/ui/Card'
 import { siteConfig, contactContent } from '@/lib/constants'
 
 export default function ContactPage() {
@@ -48,30 +47,6 @@ export default function ContactPage() {
             </Button>
           </motion.div>
 
-          {/* What I'm open to */}
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.3 }}
-            className="mt-16"
-          >
-            <Card>
-              <h2 className="font-headline text-lg font-semibold text-[var(--foreground)] mb-4">
-                What I'm open to
-              </h2>
-              <ul className="space-y-3">
-                {contactContent.openTo.map((item, index) => (
-                  <li
-                    key={index}
-                    className="flex items-center gap-3 text-[var(--muted-foreground)]"
-                  >
-                    <span className="w-2 h-2 rounded-full bg-amber-500 shrink-0" />
-                    {item}
-                  </li>
-                ))}
-              </ul>
-            </Card>
-          </motion.div>
 
           {/* Alternative contact */}
           <motion.div

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -41,10 +41,9 @@ export function AboutSection() {
             </h2>
 
             <div className="mt-8 space-y-6 text-lg text-[var(--muted-foreground)] leading-relaxed">
-              <p>
-                I specialise in taking cutting-edge manufacturing technology from "it works in the lab"
-                to "it's running 24/7 across 14 sites." That gap between prototype and production
-                is where most innovation dies, and that's where I do my best work.
+              <p className="text-[var(--foreground)] font-medium">
+                I write Python and I run factories. I can debug machine code and present
+                to a board. That bridge between the technical and the operational is where I do my best work.
               </p>
               <p>
                 My career started on the shop floor at Rolls-Royce, where I eventually led the team
@@ -52,9 +51,9 @@ export function AboutSection() {
                 across 12 countries, optimised pharmaceutical production lines at BCG, and now I'm building
                 robotic construction systems at AUAR.
               </p>
-              <p className="text-[var(--foreground)] font-medium">
-                What makes me different: I write Python and I run factories. I can debug machine code and present
-                to a board. That bridge between the technical and the operational is my sweet spot.
+              <p>
+                The gap between "it works in the lab" and "it's running 24/7 across 14 sites" is where
+                most innovation dies — and it's where I've spent my entire career.
               </p>
             </div>
           </div>

--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -34,8 +34,7 @@ export function ContactSection() {
             Let's talk
           </h2>
           <p className="mt-4 text-lg text-[var(--muted-foreground)]">
-            I'm always interested in discussing manufacturing innovation,
-            robotics, or connecting with fellow builders.
+            Always happy to talk manufacturing, robotics, or interesting problems.
           </p>
 
           <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
@@ -77,26 +76,6 @@ export function ContactSection() {
             </Button>
           </div>
 
-          <div className="mt-12 pt-8 border-t border-[var(--border)]">
-            <p className="text-sm text-[var(--muted-foreground)] mb-4">
-              Open to:
-            </p>
-            <div className="flex flex-wrap justify-center gap-3">
-              {[
-                "Advisory roles",
-                "Speaking opportunities",
-                "Robotics collaborations",
-              ].map((item, index) => (
-                <span
-                  key={item}
-                  className="animate-on-scroll px-4 py-2 text-sm bg-[var(--muted)] border border-[var(--border)] rounded-full text-[var(--foreground)] hover:border-amber-500/50 hover:shadow-[0_0_12px_rgba(245,158,11,0.2)] transition-all duration-300 cursor-default"
-                  style={{ animationDelay: `${0.3 + index * 0.1}s` }}
-                >
-                  {item}
-                </span>
-              ))}
-            </div>
-          </div>
         </div>
       </Container>
     </section>

--- a/src/components/sections/HeroSplitParallax.tsx
+++ b/src/components/sections/HeroSplitParallax.tsx
@@ -120,9 +120,9 @@ export function HeroSplitParallax() {
             <span className="text-amber-500">.</span>
           </h1>
 
-          {/* Subtitle */}
+          {/* Positioning line */}
           <p className="animate-fade-in-up delay-300 mt-6 text-lg text-[var(--muted-foreground)] max-w-md leading-relaxed">
-            Taking manufacturing technology from prototype to scale.
+            Head of Robotics at AUAR. Previously Rolls-Royce, Edwards Vacuum, BCG.
           </p>
 
           {/* Status indicator */}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -26,11 +26,11 @@ export const heroContent = {
 
 export const aboutContent = {
   headline: 'Taking manufacturing tech from pilot to scale',
-  narrative: `I'm an operations leader who specialises in the messy middle—taking cutting-edge manufacturing technology from "it works in the lab" to "it's running 24/7 across 14 sites."
+  narrative: `I write Python and I run factories. I can debug machine code and present to a board. That bridge between the technical and the operational is where I do my best work.
 
-My career started on the factory floor at Rolls-Royce, where I eventually led the team assembling the world's largest jet engine. I've since driven Industry 4.0 transformation across 12 countries, optimised pharmaceutical supply chains at BCG, and now I'm building robotic manufacturing systems at AUAR that are changing how we construct buildings.
+My career started on the shop floor at Rolls-Royce, where I eventually led the team assembling the world's largest jet engine. I've since driven Industry 4.0 transformation across 12 countries, optimised pharmaceutical production lines at BCG, and now I'm building robotic construction systems at AUAR.
 
-What makes me different: I write Python and I run P&Ls. I can debug a PLC and present to a board. That bridge between the technical and the commercial is where I do my best work.
+The gap between "it works in the lab" and "it's running 24/7 across 14 sites" is where most innovation dies — and it's where I've spent my entire career.
 
 When I'm not on a factory floor, I'm probably in my workshop—woodworking, welding, or building something that didn't exist yesterday.`,
   quickFacts: [
@@ -170,10 +170,5 @@ export const credentialsLogos = [
 
 export const contactContent = {
   headline: 'Let\'s talk',
-  description: 'I\'m always interested in discussing new opportunities, collaborations, or just connecting with fellow builders.',
-  openTo: [
-    'Advisory roles in manufacturing tech',
-    'Speaking opportunities',
-    'Collaboration on robotics & automation projects',
-  ],
+  description: 'Always happy to talk manufacturing, robotics, or interesting problems.',
 }


### PR DESCRIPTION
## Summary
- **Hero**: Replace generic subtitle with credential-anchored positioning line — "Head of Robotics at AUAR. Previously Rolls-Royce, Edwards Vacuum, BCG."
- **About**: Reorder paragraphs to lead with the distinctive "I write Python and I run factories" angle, moving career arc to supporting evidence
- **Contact**: Remove explicit "Open to:" chips and soften CTA to "Always happy to talk manufacturing, robotics, or interesting problems"

## Test plan
- [ ] Verify hero subtitle renders correctly on desktop and mobile
- [ ] Verify about section paragraph order and styling (first paragraph bold)
- [ ] Verify contact section no longer shows "Open to" chips on both homepage and /contact page
- [ ] Check light and dark mode for all changed sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)